### PR TITLE
Multiple permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import Acl from 'vue-acl'
 Vue.use( Acl, { router: Router, init: 'any' } )
 ```
 
-**[2]:** Add metadata in their routes saying which permission required to access the route, use pipe (|) to separate more than one permission, other metadata used is the ' fail ', which will indicate which route to redirect on error:
+**[2]:** Add metadata in their routes saying which permission, or group of permissions is required to access the route, use pipe (|) to do an OR check for more than one permission, use (&) to do an AND check for multiple permissions (these can be used in combination for more complex situations). Use the ' fail ' metadata to indicate which route to redirect on error:
 ```js
 [
   {
@@ -58,6 +58,16 @@ Vue.use( Acl, { router: Router, init: 'any' } )
     }
   },
   {
+    path: '/edit-delete',
+    component: require('./components/EditDelete.vue'),
+    meta: {permission: 'edit&delete', fail: '/error'}
+  },
+  {
+    path: '/edit-delete-admin',
+    component: require('./components/EditDeleteAdmin.vue'),
+    meta: {permission: 'edit&delete|admin', fail: '/error'}
+  },
+  {
     path: '/error',
     component: require('./components/Error.vue'),
     meta: {
@@ -74,13 +84,19 @@ Vue.use( Acl, { router: Router, init: 'any' } )
 <router-link v-show='$can("any")' to='/client'>To client</router-link> |
 <router-link v-show='$can("admin")' to='/manager'>To manager</router-link> |
 <router-link v-show='$can("admin|any")' to='/'>To Public</router-link>
+<router-link v-show='$can("edit&delete")' to='/'>To Edit and delete</router-link>
 ```
-This method receives a parameter with the permissions to check, separated by a pipe (|), and returns a `bool` saying if permission has been granted.
+This method receives a parameter with the permissions to check, separated by a pipe (|) or ampersand (&), and returns a `bool` saying if permission has been granted.
 
-To change the current system permission use the global method `$access()`, passing as parameter the new permission:
+To change the current system permission use the global method `$access()`, passing as parameter the new permission, or array of permissions:
 ```js
  this.$access('admin')
 ```
+or
+```js
+ this.$access(['edit', 'delete'])
+```
+
 To see the current system permission, just call the `$access()` method with no parameter.
 
 ### Contributing

--- a/demo/src/components/EditDelete.vue
+++ b/demo/src/components/EditDelete.vue
@@ -1,0 +1,11 @@
+<template>
+	<div>
+		<h1>Welcome to edit & delete page</h1>
+	</div>
+</template>
+
+<script>
+export default{
+	name: 'lv-edit-delete',
+}
+</script>

--- a/demo/src/components/EditDeleteAdmin.vue
+++ b/demo/src/components/EditDeleteAdmin.vue
@@ -1,0 +1,11 @@
+<template>
+	<div>
+		<h1>Welcome to edit & delete or admin page</h1>
+	</div>
+</template>
+
+<script>
+export default{
+	name: 'lv-edit-delete-admin',
+}
+</script>

--- a/demo/src/components/Init.vue
+++ b/demo/src/components/Init.vue
@@ -1,33 +1,42 @@
 <template>
-	<div>
-		<h1>Welcome the vue-acl demo</h1>
-		<small>Accessing with {{ active }}</small>
-		<hr>
-		<button @click="change('admin')">Change to admin access</button>
-		<button @click="change('any')">Change to any access</button>
-		<hr>
-		<router-link to="/">To public page</router-link>
-		<hr>
-		<router-view></router-view>
-	</div>
+    <div>
+        <h1>Welcome the vue-acl demo</h1>
+        <small>Accessing with {{ active }}</small>
+        <hr>
+        <button @click="change('admin')">Change to admin access</button>
+        <button @click="change('any')">Change to any access</button>
+        <hr>
+        <button @click="add('edit')">Add edit permission</button>
+        <button @click="add('delete')">Add delete permission</button>
+        <hr>
+        <router-link to="/">To public page</router-link>
+        <hr>
+        <router-view></router-view>
+    </div>
 </template>
 
 <script>
-export default{
-	name: 'lv-init',
-	data() {
-		return { active: this.$access() }
-	},
-	methods: {
-		change(access) {
-			this.$access(access)
-			this.active = this.$access()
+    export default{
+        name: 'lv-init',
+        data() {
+            return {active: this.$access()}
+        },
+        methods: {
+            change(access) {
+                this.$access(access)
+                this.active = this.$access()
 
-			if( this.$can('admin') )
-				alert('Hello, admin')
-			else
-				alert('No is admin')
-		}
-	}
-}
+                if (this.$can('admin'))
+                    alert('Hello, admin')
+                else
+                    alert('No is admin')
+            },
+            add(permission) {
+                if (this.active.indexOf(permission) === -1) {
+                    this.active.push(permission);
+                    this.$access(this.active);
+                }
+            }
+        }
+    }
 </script>

--- a/demo/src/components/Public.vue
+++ b/demo/src/components/Public.vue
@@ -1,14 +1,16 @@
 <template>
-	<div>
-		<h1>Welcome to public page</h1>
-		<hr>
-		<router-link to="/manager">To manager page</router-link>
-		<router-link to="/client">To client page</router-link>
-	</div>
+    <div>
+        <h1>Welcome to public page</h1>
+        <hr>
+        <router-link to="/manager">To manager page</router-link>
+        <router-link to="/client">To client page</router-link>
+        <router-link to="/edit-delete">To edit and delete page</router-link>
+        <router-link to="/edit-delete-admin">To edit and delete or manager page</router-link>
+    </div>
 </template>
 
 <script>
-export default{
-	name: 'lv-public',
-}
+    export default{
+        name: 'lv-public',
+    }
 </script>

--- a/demo/src/main.js
+++ b/demo/src/main.js
@@ -22,6 +22,16 @@ const routes = [
     meta: {permission: 'any', fail: '/error'}
   },
   {
+    path: '/edit-delete',
+    component: require('./components/EditDelete.vue'),
+    meta: {permission: 'edit&delete', fail: '/error'}
+  },
+  {
+    path: '/edit-delete-admin',
+    component: require('./components/EditDeleteAdmin.vue'),
+    meta: {permission: 'edit&delete|admin', fail: '/error'}
+  },
+  {
     path: '/error',
     component: require('./components/Error.vue'),
     meta: {permission: 'admin|any'}

--- a/src/es5.js
+++ b/src/es5.js
@@ -1,7 +1,7 @@
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
-	value: true
+    value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -9,59 +9,78 @@ var _createClass = function () { function defineProperties(target, props) { for 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var Acl = function () {
-	function Acl() {
-		_classCallCheck(this, Acl);
-	}
+    function Acl() {
+        _classCallCheck(this, Acl);
+    }
 
-	_createClass(Acl, [{
-		key: 'init',
-		value: function init(router, permission) {
-			this.router = router;
-			this.permission = permission;
-		}
-	}, {
-		key: 'check',
-		value: function check(permission) {
-			if (typeof permission != 'undefined') permission = permission.indexOf('|') !== -1 ? permission.split('|') : permission;
+    _createClass(Acl, [{
+        key: 'init',
+        value: function init(router, permissions) {
+            this.router = router;
+            this.permissions = Array.isArray(permissions) ? permissions : [permissions];
+        }
+    }, {
+        key: 'check',
+        value: function check(permission) {
+            var _this = this;
 
-			if (Array.isArray(permission)) return permission.indexOf(this.permission) !== -1 ? true : false;else return this.permission == permission;
-		}
-	}, {
-		key: 'router',
-		set: function set(router) {
-			var _this = this;
+            if (typeof permission != 'undefined') {
+                var permissions = permission.indexOf('|') !== -1 ? permission.split('|') : [permission];
 
-			router.beforeEach(function (to, from, next) {
-				var fail = to.meta.fail || '/';
-				if (typeof to.meta.permission == 'undefined') return next(fail);else {
-					if (!_this.check(to.meta.permission)) return next(fail);
-					next();
-				}
-			});
-		}
-	}]);
+                return permissions.find(function (permission) {
+                        console.log('Checking: ', permission);
 
-	return Acl;
+                        var needed = permission.indexOf('&') !== -1 ? permission.split('&') : permission;
+
+                        if (Array.isArray(needed)) {
+                            return needed.every(function (need) {
+                                return _this.permissions.indexOf(need) !== -1;
+                            });
+                        }
+
+                        return _this.permissions.indexOf(needed) !== -1 ? true : false;
+                    }) !== undefined;
+            }
+            return false;
+        }
+    }, {
+        key: 'router',
+        set: function set(router) {
+            var _this2 = this;
+
+            router.beforeEach(function (to, from, next) {
+                var fail = to.meta.fail || '/';
+                if (typeof to.meta.permission == 'undefined') return next(fail);else {
+                    if (!_this2.check(to.meta.permission)) return next(fail);
+                    next();
+                }
+            });
+        }
+    }]);
+
+    return Acl;
 }();
 
 var acl = new Acl();
 
 Acl.install = function (Vue, _ref) {
-	var router = _ref.router,
-	    init = _ref.init;
+    var router = _ref.router,
+        init = _ref.init;
 
 
-	acl.init(router, init);
+    acl.init(router, init);
 
-	Vue.prototype.$can = function (permission) {
-		return acl.check(permission);
-	};
+    Vue.prototype.$can = function (permission) {
+        return acl.check(permission);
+    };
 
-	Vue.prototype.$access = function () {
-		var newAccess = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
+    Vue.prototype.$access = function () {
+        var newAccess = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
 
-		if (newAccess != null) acl.permission = newAccess;else return acl.permission;
-	};
+        if (newAccess != null) {
+            if (Array.isArray(newAccess)) acl.permissions = newAccess;else acl.permissions = [newAccess];
+        } else return acl.permissions;
+    };
 };
 
 exports.default = Acl;


### PR DESCRIPTION
Hey, really like your package, real lean and effective.

For our project however, we have a more complex acl model which is based on  users having more than one permission. For instance, a user can have the 'edit' permission to update a certain resource, but not have the 'delete' permission, to remove said resource from the database.
In some situations, we also need to check if a user has more than one permission, for instance, both the edit and delete permissions might be needed for a certain action.

I have forked your repo, and created a pull request to do both these things:
* I changed the internal ``permission`` property to ``permissions``, which is now an array. 
* The ``this.$access()`` function can now take both arrays or strings, which are internally changed to an array with one key.
* The check method compares the array of requested permissions to the array of set permissions. This still works with all the previous use cases.
* The check method now also recognizes the ``&`` character to check not one but multiple permissions are set. This can  be combined with the ``|`` character  to check more complex situations>
* I've added 2 situations to illustrate this to the demo
* I've also added some lines to your readme to explain these new possibilities, however, my Portuguese is very limited, so I could not update the other readme file...

I hope you like this added functionality, I made sure it is still possible to use the package in the same way as before, if you do not want to use these new functions. 