### PR TITLE
Empty Permission makes route unprotected #ES5

### DIFF
--- a/src/es5.js
+++ b/src/es5.js
@@ -25,6 +25,8 @@ var Acl = function () {
             var _this = this;
 
             if (typeof permission != 'undefined') {
+                if(permission == '')
+                    return true
                 var permissions = permission.indexOf('|') !== -1 ? permission.split('|') : [permission];
 
                 return permissions.find(function (permission) {


### PR DESCRIPTION
leaving Permissions empty in meta of routes makes it unprotected. Useful for login page etc that do not require any permissions. Leaving that to 'any' permissions defined in the beginning is bad practice since it gets overwritten by the permissions received from the server.
