### PR TITLE
Allow change to check new generated acl rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ export default new Router({
       name: 'notfound',
       component: NotFound,
       meta: {
-        rule: '*'
+        rule: ['*']
       }
     }
   ]
@@ -101,7 +101,7 @@ export default new Router({
 ```
 
 More details:
-- Define `rule` meta for link a route with a permission, your can use name of the global rule e.g `isPublic` or use `AclRule` for create new rule orr use `*` for define allowed route.
+- Define `rule` meta for link a route with a permission, your can use name of the global rule e.g `isPublic` or use `AclRule` for create new rule or use `[*]` for define allowed route.
 
 For finish, in your `main.js` import the `acl` and pass to Vue root instance:
 

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -10,16 +10,61 @@
       <button @click="$acl.change('read')">Turn public</button>
     </section>
 
-    <p style="padding: 10px">Current permission: {{ $acl.get }}</p>
+    <p style="padding: 10px">
+      Current permission: {{ $acl.get }}.
+      <span v-if="$acl.check('isLocalRule')">This span can be seen if have 'write' permission.</span>
+    </p>
 
-    <hr>
-    <p><small>Page content:</small></p>
-    <router-view/>
+    <p style="padding: 10px" v-if="$acl.check($router.currentRoute.meta.rule)">Always Ture
+    </p>
+
+    <section style="display: flex; padding: 10px">
+      <button @click="assignCheckConditionToWriteOnly()">Change check condition to 'write only'</button>
+      <button
+        @click="assignCheckConditionToReadAndWrite()"
+      >Change check condition to 'read and write'</button>
+      <button @click="assignCheckConditionToReadOrWrite()">Change check condition to 'read or write'</button>
+    </section>
+
+    <p style="padding-left: 10px">Current check condition is: '{{ checkRuleInfo }}'</p>
+    <p style="padding-left: 10px">Check result is: '{{ $acl.check(checkRuleVariable) }}'</p>
+
+    <hr />
+    <p>
+      <small>Page content:</small>
+    </p>
+    <router-view />
   </div>
 </template>
 
 <script>
+import { AclRule } from "../../source";
 export default {
-  name: 'App'
-}
+  name: "App",
+  data() {
+    return {
+      checkRuleVariable: null,
+      checkRuleInfo: ""
+    };
+  },
+  computed: {
+    isLocalRule() {
+      return new AclRule("write").generate();
+    }
+  },
+  methods: {
+    assignCheckConditionToWriteOnly() {
+      this.checkRuleVariable = new AclRule("write").generate();
+      this.checkRuleInfo = "write only";
+    },
+    assignCheckConditionToReadAndWrite() {
+      this.checkRuleVariable = new AclRule("read").and("write").generate();
+      this.checkRuleInfo = "read and write";
+    },
+    assignCheckConditionToReadOrWrite() {
+      this.checkRuleVariable = new AclRule("read").or("write").generate();
+      this.checkRuleInfo = "read or write";
+    }
+  }
+};
 </script>

--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -54,15 +54,15 @@ export default {
   },
   methods: {
     assignCheckConditionToWriteOnly() {
-      this.checkRuleVariable = new AclRule("write").generate();
+      this.checkRuleVariable = new AclRule("write");
       this.checkRuleInfo = "write only";
     },
     assignCheckConditionToReadAndWrite() {
-      this.checkRuleVariable = new AclRule("read").and("write").generate();
+      this.checkRuleVariable = new AclRule("read").and("write");
       this.checkRuleInfo = "read and write";
     },
     assignCheckConditionToReadOrWrite() {
-      this.checkRuleVariable = new AclRule("read").or("write").generate();
+      this.checkRuleVariable = new AclRule("read").or("write");
       this.checkRuleInfo = "read or write";
     }
   }

--- a/example/src/router.js
+++ b/example/src/router.js
@@ -5,6 +5,7 @@ import { AclRule } from '../../source'
 import Public from './views/Public.vue'
 import Admin from './views/Admin.vue'
 import NotFound from './views/NotFound.vue'
+import Asterisk from './views/Asterisk.vue'
 
 Vue.use(Router)
 
@@ -33,6 +34,22 @@ export default new Router({
       meta: {
         rule: '*'
       }
-    }
+    },
+    {
+      path: '/asterisk-invalid',
+      name: 'asterisk',
+      component: Asterisk,
+      meta: {
+        rule: '*'
+      }
+    },
+    {
+      path: '/asterisk-valid',
+      name: 'asterisk',
+      component: Asterisk,
+      meta: {
+        rule: ['*']
+      }
+    },
   ]
 })

--- a/example/src/views/Asterisk.vue
+++ b/example/src/views/Asterisk.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="asterisk">
+    <h1>This is an asterisk page</h1>
+  </div>
+</template>

--- a/source/checker.js
+++ b/source/checker.js
@@ -1,8 +1,9 @@
+import { AclRule } from './index'
 
 /**
  * Test a rule with a permission group
  * @param {Array} current current permissions
- * @param {Array} rules rule to test
+ * @param {Array|AclRule} rules rule to test
  * @return {boolean} valided rule
  */
 export const testPermission =(current, rules) => {

--- a/source/mixin.js
+++ b/source/mixin.js
@@ -84,7 +84,7 @@ export const register = (initial, acceptLocalRules, globalRules, router, notfoun
 
         /**
          * Check if rule is valid currently
-         * @param {string} ruleName rule name
+         * @param {string|Array} ruleName rule name
          */
         check(ruleName) {
           const hasNot = not
@@ -102,6 +102,11 @@ export const register = (initial, acceptLocalRules, globalRules, router, notfoun
             }
 
             const result = testPermission(this.get, self[ruleName])
+            return hasNot ? !result : result
+          }
+
+          if (Array.isArray(ruleName)) {
+            const result = testPermission(this.get, ruleName)
             return hasNot ? !result : result
           }
 

--- a/source/mixin.js
+++ b/source/mixin.js
@@ -2,7 +2,7 @@
 import Vue from 'vue'
 
 import { testPermission } from './checker'
-
+import { AclRule } from './index'
 
 
 
@@ -84,29 +84,28 @@ export const register = (initial, acceptLocalRules, globalRules, router, notfoun
 
         /**
          * Check if rule is valid currently
-         * @param {string|Array} ruleName rule name
+         * @param {string|Array|AclRule} rule rule
          */
-        check(ruleName) {
+        check(rule) {
           const hasNot = not
           not = false
 
-          if (ruleName in globalRules) {
-            const result = testPermission(this.get, globalRules[ruleName])
+          if (typeof rule === 'string' && rule in globalRules) {
+            const result = testPermission(this.get, globalRules[rule])
             return hasNot ? !result : result
           }
 
-
-          if (ruleName in self) {
+          if (typeof rule === 'string' && rule in self) {
             if (!acceptLocalRules) {
               return console.error('[vue-acl] acceptLocalRules is not enabled')
             }
 
-            const result = testPermission(this.get, self[ruleName])
+            const result = testPermission(this.get, self[rule])
             return hasNot ? !result : result
           }
 
-          if (Array.isArray(ruleName)) {
-            const result = testPermission(this.get, ruleName)
+          if (Array.isArray(rule) || rule instanceof AclRule) {
+            const result = testPermission(this.get, rule)
             return hasNot ? !result : result
           }
 


### PR DESCRIPTION
Hi @leonardovilarinho 

I found the '*' asterisk rule doesn't work. It will raise `'[vue-acl] you have invalid rules'` in `checker.js`, however `['*']` works. Please check the `asterisk-invalid` and `asterisk-valid` in the example.

I also made changes to allow `$acl.change()` to accept `AclRule('key').generate()` and `AclRule('key')` directly. Please see the code in `example/src/App.vue` as well.