### PR TITLE
checker update

### DIFF
--- a/source/checker.js
+++ b/source/checker.js
@@ -6,8 +6,12 @@
  * @return {boolean} valided rule
  */
 export const testPermission =(current, rules) => {
+  if (rule === '*') {
+    return true;
+  }
+  
   if (rules.generate === undefined && !Array.isArray(rules)) {
-    return console.error('[vue-acl] you have invalid rules');
+    return console.error('[vue-acl] you have invalid rules: ' + JSON.stringify(rules));
   }
 
   if (!Array.isArray(rules)) {
@@ -16,7 +20,7 @@ export const testPermission =(current, rules) => {
 
   let hasAllowed = false;
   rules.forEach((rule) => {
-    if (rule === '*') hasAllowed = true;
+    
   });
 
   if (hasAllowed) return true;

--- a/source/checker.js
+++ b/source/checker.js
@@ -19,12 +19,6 @@ export const testPermission =(current, rules) => {
   }
 
   let hasAllowed = false;
-  rules.forEach((rule) => {
-    
-  });
-
-  if (hasAllowed) return true;
-
   let checkAnds;
   // If current rule is an array then use the Array.prototype.include
   if (Array.isArray(current)) {


### PR DESCRIPTION
https://github.com/leonardovilarinho/vue-acl/blob/affd849636e24f00c5be6e83faa86d8d6bc9ffe8/source/checker.js#L9

This line doesn't allow a router rule such as:
```js
meta: {
    rule: '*'
}
```

to go through, It remains invalid, as it is not a predefined rule, which means this section let's it run through as a simple string:
https://github.com/leonardovilarinho/vue-acl/blob/affd849636e24f00c5be6e83faa86d8d6bc9ffe8/source/mixin.js#L36-L40

not being an array and not having a `.generate` function.

Event if it got through, by using:

```js
meta: {
    rule: new AclRule('*')
}
```

The result of `.generate()` is an array of an array: `[['*']]`, hence the following line: https://github.com/leonardovilarinho/vue-acl/blob/affd849636e24f00c5be6e83faa86d8d6bc9ffe8/source/checker.js#L19 also fails.

Consider the mentioned simplification.