### PR TITLE
Not Found redirection improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ export default new AclCreate({
   },
   middleware: async acl => {
     await timeout(2000) // call your api
-    acl.change('admin')
+    acl.change('admin', { name: 'page-not-authorized' })
   }
 })
 ```

--- a/dist/mixin.js
+++ b/dist/mixin.js
@@ -75,7 +75,7 @@ var register = exports.register = function register(initial, acceptLocalRules, g
                 }
 
                 if ((0, _checker.testPermission)(currentGlobal, routePermission)) {
-                  _context.next = 14;
+                  _context.next = 15;
                   break;
                 }
 
@@ -83,12 +83,15 @@ var register = exports.register = function register(initial, acceptLocalRules, g
                 if (forwardQueryParams) {
                   notFound.query = to.query;
                 }
+
+                notFound.meta.from = to;
+
                 return _context.abrupt('return', next(notFound));
 
-              case 14:
+              case 15:
                 return _context.abrupt('return', next());
 
-              case 15:
+              case 16:
               case 'end':
                 return _context.stop();
             }

--- a/dist/mixin.js
+++ b/dist/mixin.js
@@ -27,7 +27,7 @@ var register = exports.register = function register(initial, acceptLocalRules, g
   if (router !== null) {
     router.beforeEach(function () {
       var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(to, from, next) {
-        var notFoundPath, routePermission;
+        var forwardQueryParams, notFound, routePermission;
         return regeneratorRuntime.wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
@@ -40,31 +40,33 @@ var register = exports.register = function register(initial, acceptLocalRules, g
                 _context.next = 3;
                 return middleware({
                   change: function change(a) {
+                    var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : notfound;
+
                     currentGlobal = a;
+                    notfound = b;
                   }
                 });
 
               case 3:
+                forwardQueryParams = notfound.forwardQueryParams;
+                notFound = router.resolve(notfound).resolved;
 
-                // to be backwards compatible (notfound could be string)
-                notFoundPath = notfound.path || notfound;
-
-                if (!(to.path === notFoundPath)) {
-                  _context.next = 6;
+                if (!(to === notFound)) {
+                  _context.next = 7;
                   break;
                 }
 
                 return _context.abrupt('return', next());
 
-              case 6:
+              case 7:
                 if ('rule' in to.meta) {
-                  _context.next = 8;
+                  _context.next = 9;
                   break;
                 }
 
                 return _context.abrupt('return', console.error('[vue-acl] ' + to.path + ' not have rule'));
 
-              case 8:
+              case 9:
                 routePermission = to.meta.rule;
 
 
@@ -77,15 +79,11 @@ var register = exports.register = function register(initial, acceptLocalRules, g
                   break;
                 }
 
-                if (!notfound.forwardQueryParams) {
-                  _context.next = 13;
-                  break;
+                // check if forwardQueryParams is set
+                if (forwardQueryParams) {
+                  notFound.query = to.query;
                 }
-
-                return _context.abrupt('return', next({ path: notFoundPath, query: to.query }));
-
-              case 13:
-                return _context.abrupt('return', next(notFoundPath));
+                return _context.abrupt('return', next(notFound));
 
               case 14:
                 return _context.abrupt('return', next());
@@ -109,8 +107,6 @@ var register = exports.register = function register(initial, acceptLocalRules, g
      * Called before create component
      */
     beforeCreate: function beforeCreate() {
-      var _this = this;
-
       var self = this;
 
       this.$acl = {
@@ -166,25 +162,22 @@ var register = exports.register = function register(initial, acceptLocalRules, g
           return false;
         }
       };
-
-      EventBus.$on('vueacl-permission-changed', function (newPermission) {
-        currentGlobal = newPermission;
-        if ('onChange' in _this.$acl) {
-          _this.$acl.onChange(currentGlobal);
-        }
-        _this.$forceUpdate();
-      });
+    },
+    created: function created() {
+      EventBus.$on('vueacl-permission-changed', this.vue_aclOnChange);
     },
     destroyed: function destroyed() {
-      var _this2 = this;
+      EventBus.$off('vueacl-permission-changed', this.vue_aclOnChange);
+    },
 
-      EventBus.$off('vueacl-permission-changed', function (newPermission) {
+    methods: {
+      vue_aclOnChange: function vue_aclOnChange(newPermission) {
         currentGlobal = newPermission;
-        if ('onChange' in _this2.$acl) {
-          _this2.$acl.onChange(currentGlobal);
+        if ('onChange' in this.$acl) {
+          this.$acl.onChange(currentGlobal);
         }
-        _this2.$forceUpdate();
-      });
+        this.$forceUpdate();
+      }
     }
   };
 };

--- a/dist/mixin.js
+++ b/dist/mixin.js
@@ -21,7 +21,7 @@ var EventBus = new _vue2.default();
 var currentGlobal = [];
 var not = false;
 
-var register = exports.register = function register(initial, acceptLocalRules, globalRules, router, notfound, middleware) {
+var register = exports.register = function register(initial, acceptLocalRules, globalRules, router, notFoundOptions, middleware) {
   currentGlobal = Array.isArray(initial) ? initial : [initial];
 
   if (router !== null) {
@@ -40,18 +40,18 @@ var register = exports.register = function register(initial, acceptLocalRules, g
                 _context.next = 3;
                 return middleware({
                   change: function change(a) {
-                    var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : notfound;
+                    var b = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : notFoundOptions;
 
                     currentGlobal = a;
-                    notfound = b;
+                    notFoundOptions = b;
                   }
                 });
 
               case 3:
-                forwardQueryParams = notfound.forwardQueryParams;
-                notFound = router.resolve(notfound).resolved;
+                forwardQueryParams = notFoundOptions.forwardQueryParams;
+                notFound = router.resolve(notFoundOptions).resolved;
 
-                if (!(to === notFound)) {
+                if (!(to.path === notFound.path)) {
                   _context.next = 7;
                   break;
                 }
@@ -81,7 +81,8 @@ var register = exports.register = function register(initial, acceptLocalRules, g
 
                 // check if forwardQueryParams is set
                 if (forwardQueryParams) {
-                  notFound.query = to.query;
+                  notFoundOptions.query = to.query;
+                  notFound = router.resolve(notFoundOptions).resolved;
                 }
 
                 notFound.meta.from = to;

--- a/dist/router.js
+++ b/dist/router.js
@@ -22,7 +22,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 // @ts-check
 var upRouter = exports.upRouter = function upRouter(router, currentGlobal, notfound) {
   if (router === null) return;
-  router.beforeEach(function (to, from, next) {
+  router.beforeRouteEnter(function (to, from, next) {
 
     /** @type {Array} */
     var routePermission = to.meta.rule;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-acl",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-acl",
-  "version": "4.1.10",
+  "version": "4.2.0",
   "description": "Plugin of Access Control List from Vue JS 2",
   "main": "dist/index.js",
   "scripts": {

--- a/source/mixin.js
+++ b/source/mixin.js
@@ -12,22 +12,22 @@ let currentGlobal = []
 let not = false
 
 
-export const register = (initial, acceptLocalRules, globalRules, router, notfound, middleware) => {
+export const register = (initial, acceptLocalRules, globalRules, router, notFoundOptions, middleware) => {
   currentGlobal = Array.isArray(initial) ? initial : [initial]
 
   if (router !== null) {
     router.beforeEach(async (to, from, next) => {
       if (middleware) {
-        await middleware({change (a, b=notfound) {
+        await middleware({change (a, b=notFoundOptions) {
           currentGlobal = a
-          notfound = b
+          notFoundOptions = b
         }})
       }
 
-      const forwardQueryParams = notfound.forwardQueryParams
-      const notFound = router.resolve(notfound).resolved
+      const forwardQueryParams = notFoundOptions.forwardQueryParams
+      let notFound = router.resolve(notFoundOptions).resolved
 
-      if (to === notFound) return next()
+      if (to.path === notFound.path) return next()
 
       /** @type {Array} */
       if (!('rule' in to.meta)) {
@@ -42,7 +42,8 @@ export const register = (initial, acceptLocalRules, globalRules, router, notfoun
       if (!testPermission(currentGlobal, routePermission)) {
         // check if forwardQueryParams is set
         if (forwardQueryParams) {
-          notFound.query = to.query
+          notFoundOptions.query = to.query
+          notFound = router.resolve(notFoundOptions).resolved
         }
 
         notFound.meta.from = to

--- a/source/mixin.js
+++ b/source/mixin.js
@@ -44,6 +44,9 @@ export const register = (initial, acceptLocalRules, globalRules, router, notfoun
         if (forwardQueryParams) {
           notFound.query = to.query
         }
+
+        notFound.meta.from = to
+
         return next(notFound)
       }
       return next()


### PR DESCRIPTION
Middleware can be used to change notFound path.
I used it to change not found according to the user connection.

notFound parameter can accept same configuration as router.push:
 - { name: 'route-name' }
 - '/path'
 - { path: '/path' }
...